### PR TITLE
Added trigger services for world_modeling

### DIFF
--- a/src/viper_ros/setup.py
+++ b/src/viper_ros/setup.py
@@ -6,7 +6,7 @@ import json
 
 from std_msgs.msg import *
 from sensor_msgs.msg import *
-
+from std_srvs.srv import Trigger
 
 from soma_manager.srv import SOMA2QueryObjs, SOMA2QueryObjsRequest
 #from soma_msgs.msg import * #from soma_roi_manager.soma_roi import SOMAROIQuery
@@ -29,6 +29,14 @@ class Setup(smach.State):
         soma_conf = userdata.soma_conf
         roi_id   = userdata.roi_id
         surface_roi_id   = userdata.surface_roi_id
+
+        # here we inform the world_modeling package that a sequence of observations is about to begin
+        try:
+            begin_observations_trigger = rospy.ServiceProxy('/begin_observations',Trigger)
+            begin_observations_trigger()
+        except rospy.ServiceException, e:
+            rospy.logerr("Service call failed: %s"%e)
+
 
 
         rospy.loginfo("Waiting for soma query service")

--- a/src/viper_ros/shutdown.py
+++ b/src/viper_ros/shutdown.py
@@ -11,6 +11,8 @@ from actionlib import *
 from actionlib.msg import *
 from scitos_ptu.msg import PtuGotoAction,PtuGotoGoal
 
+from std_srvs.srv import Trigger
+
 class Shutdown(smach.State):
     """
     Shutdown
@@ -27,9 +29,11 @@ class Shutdown(smach.State):
 
     def execute(self, userdata):
 
+
+
         goal = PtuGotoGoal()
         goal.pan = 0.0
-        goal.tilt = 0.0 
+        goal.tilt = 0.0
         goal.pan_vel = 60
         goal.tilt_vel = 60
         rospy.loginfo("SET PTU: pan: %f tilt: %f", goal.pan, goal.tilt)
@@ -37,5 +41,13 @@ class Shutdown(smach.State):
         self.ptu_client.wait_for_result()
         rospy.loginfo("Reached ptu goal")
 
-        return 'succeeded'
+        # here we inform the world_modeling package that a sequence of observations has finished
+        # I'm doing this at the end here because it blocks while the world_modeling system does its processing
+        # which could take 5-10 seconds
+        try:
+            end_observations_trigger = rospy.ServiceProxy('/end_observations',Trigger)
+            end_observations_trigger()
+        except rospy.ServiceException, e:
+            rospy.logerr("Service call failed: %s"%e)
 
+        return 'succeeded'


### PR DESCRIPTION
This adds calls to two trigger services provided by the latest version of world_modeling, which tell the system to prepare for an incoming sequence of views, and to post-process that sequence of views once all the observations have been made.

I've added these calls to the SetUp and ShutDown states. 

This is all in support of the new major revision of world_modeling which utilises arbitrary view alignment to create merged point clouds, more on that here: https://github.com/jayyoung/world_modeling/pull/6
