### PR TITLE
Integrates object_full mode with the KTH learning pipeline

### DIFF
--- a/scripts/demand_object_search_task.py
+++ b/scripts/demand_object_search_task.py
@@ -14,7 +14,7 @@ def get_services():
     rospy.loginfo("Waiting for task_executor service...")
     rospy.wait_for_service(demand_task_srv_name)
     rospy.wait_for_service(set_exe_stat_srv_name)
-    rospy.loginfo("Done")        
+    rospy.loginfo("Done")
     add_tasks_srv = rospy.ServiceProxy(demand_task_srv_name, DemandTask)
     set_execution_status = rospy.ServiceProxy(set_exe_stat_srv_name, SetExecutionStatus)
     return add_tasks_srv, set_execution_status
@@ -41,13 +41,13 @@ if __name__ == '__main__':
     set_execution_status(True)
     print 'set execution'
 
-    task= Task(action='search_object', max_duration=rospy.Duration(600), start_node_id=waypoint)
+    task= Task(action='search_object', max_duration=rospy.Duration(600), start_node_id=waypoint, priority=9000)
     task_utils.add_string_argument(task, waypoint)
     task_utils.add_string_argument(task, roi)
     task_utils.add_string_argument(task, surface_roi)
     task_utils.add_string_argument(task, mode)
+    print 'sending task demand'
     resp = demand_task(task)
-    print 'demanded task as id: %s' % resp.task_id
+    print 'task accepted, demanded task as id: %s' % resp.task_id
     rospy.loginfo('Success: %s' % resp.success)
     rospy.loginfo('Wait: %s' % resp.remaining_execution_time)
-

--- a/src/viper_ros/perception.py
+++ b/src/viper_ros/perception.py
@@ -333,7 +333,14 @@ class PerceptionReal (smach.State):
             rospy.loginfo('Waiting for pointcloud: %s', self.pc_frame)
             pointcloud = rospy.wait_for_message(self.pc_frame, PointCloud2 , timeout=60.0)
             rospy.loginfo('Got pointcloud')
-            res = self.process_scene_srv(input=pointcloud,waypoint=userdata.waypoint)
+            rospy.loginfo("MODE: " + userdata.mode)
+            # if false, means that the full BHAM object-learning pipeline will be run on observations
+            # if true, means that only data collection will be performed, with observed scenes saved in soma_llsd
+            collection_mode = False
+            if userdata.mode == 'object_full':
+                collection_mode = True;
+
+            res = self.process_scene_srv(input=pointcloud,waypoint=userdata.waypoint,just_data_collection=collection_mode)
 
             if len(res.objects) > 0:
                 vinfo.success = True

--- a/src/viper_ros/view_planning.py
+++ b/src/viper_ros/view_planning.py
@@ -228,6 +228,7 @@ class ViewPlanning(smach.State):
             rospy.set_param('max_tilt', '0.52')
             try:
                 # call action server to do meta-room at waypoint
+                rospy.loginfo("Doing a metric-map")
                 meta_room_action_server_name = "/do_sweep"
                 client = actionlib.SimpleActionClient(meta_room_action_server_name, SweepAction)
                 client.wait_for_server(rospy.Duration(60))
@@ -237,16 +238,18 @@ class ViewPlanning(smach.State):
                 # wait for meta-room to be processed
 
                 # get dynamic clusters point cloud
+                rospy.loginfo("waiting to receive dynamic clusters. Timeout 4 minutes....")
                 dynamic_clusters = rospy.wait_for_message("/quasimodo/segmentation/roomObservation/dynamic_clusters",PointCloud2,60*4)
 
                 # call service to turn point cloud to octomap
                 rospy.loginfo("waiting for octomap conversion service")
                 conv_octomap = rospy.ServiceProxy('/surface_based_object_learning/convert_pcd_to_octomap',ConvertCloudToOctomap)
+                rospy.loginfo("Converting point cloud of dynamic clusters to octomap")
                 oct_response = conv_octomap([dynamic_clusters]) #service takes a list, if you want to merge multiple clouds into a single octo
 
                 # do normal view planning
                 octomap = oct_response.octomap
-
+                rospy.loginfo("All done!")
                 # perceieve using pass_through perception (done later, in perception.py)
 
             except Exception,e:

--- a/src/viper_ros/view_planning.py
+++ b/src/viper_ros/view_planning.py
@@ -232,7 +232,7 @@ class ViewPlanning(smach.State):
                 meta_room_action_server_name = "/do_sweep"
                 client = actionlib.SimpleActionClient(meta_room_action_server_name, SweepAction)
                 client.wait_for_server(rospy.Duration(60))
-                goal = SweepActionGoal(type='medium')
+                goal = SweepGoal(type = 'medium')
                 client.send_goal(goal)
                 client.wait_for_result(rospy.Duration(60*1)) # usually takes about ~20 seconds
                 # wait for meta-room to be processed

--- a/src/viper_ros/view_planning.py
+++ b/src/viper_ros/view_planning.py
@@ -232,7 +232,7 @@ class ViewPlanning(smach.State):
                 meta_room_action_server_name = "/do_sweep"
                 client = actionlib.SimpleActionClient(meta_room_action_server_name, SweepAction)
                 client.wait_for_server(rospy.Duration(60))
-                goal = SweepActioneGoal(type='medium')
+                goal = SweepActionGoal(type='medium')
                 client.send_goal(goal)
                 client.wait_for_result(rospy.Duration(60*1)) # usually takes about ~20 seconds
                 # wait for meta-room to be processed


### PR DESCRIPTION
This adds the ability to run tasks in the 'object_full' mode: doing a meta-room scan, converting to octomap, waiting for dynamic clusters, and then doing a data-collection only learning episode. It relies on the whole multi_object_learning pipeline, including surface_based_object_learning, initial_surface_view_evaluation, as well as QUASIMODO and the strands_3d_mapping sweep service.

Also edited the demand task script to now include a priority.